### PR TITLE
fixed animation play block

### DIFF
--- a/blocks/graphics/animationplayer_play.tres
+++ b/blocks/graphics/animationplayer_play.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" load_steps=7 format=3 uid="uid://c5e1byehtxwc0"]
+[gd_resource type="Resource" load_steps=5 format=3 uid="uid://c5e1byehtxwc0"]
 
 [ext_resource type="Script" path="res://addons/reblocks/code_generation/block_definition.gd" id="1_emeuv"]
 [ext_resource type="Script" path="res://addons/reblocks/code_generation/option_data.gd" id="1_xu43h"]
@@ -9,16 +9,6 @@ script = ExtResource("1_xu43h")
 selected = 0
 items = []
 
-[sub_resource type="Resource" id="Resource_vnp2w"]
-script = ExtResource("1_xu43h")
-selected = 0
-items = ["forward", "backwards"]
-
-[sub_resource type="Resource" id="Resource_17pec"]
-script = ExtResource("1_xu43h")
-selected = 0
-items = ["until done", "in the background"]
-
 [resource]
 script = ExtResource("1_emeuv")
 name = &"animationplayer_play"
@@ -27,18 +17,13 @@ description = "Play the animation."
 category = "Graphics | Animation"
 type = 2
 variant_type = 0
-display_template = "play {animation: STRING} | {direction: NIL} {wait_mode: NIL}"
-code_template = "if {direction} == \"forward\":
-	play({animation})
-else:
-	play_backwards({animation})
-if {wait_mode} == \"until done\":
-	await animation_finished
+display_template = "play {animation: STRING}"
+code_template = "play({animation})
+
+
 "
 defaults = {
-"animation": SubResource("Resource_qpxn2"),
-"direction": SubResource("Resource_vnp2w"),
-"wait_mode": SubResource("Resource_17pec")
+"animation": SubResource("Resource_qpxn2")
 }
 signal_name = ""
 is_advanced = false


### PR DESCRIPTION
The Animation block had hard coded functionality in it and couldn't be used as a general block for playing animations, it could only be used with a specific custom block. I removed the hard coded functionality and made it so it can now be used as a normal block.